### PR TITLE
`A-CodeQuality` branch

### DIFF
--- a/src/main/java/commands/DeleteCommand.java
+++ b/src/main/java/commands/DeleteCommand.java
@@ -4,6 +4,7 @@ import dukeegg.Storage;
 import dukeegg.TaskList;
 import dukeegg.Ui;
 import exceptions.DukeException;
+import exceptions.InvalidTaskIndexException;
 import task.Task;
 
 /**
@@ -27,11 +28,15 @@ public class DeleteCommand extends Command {
      * {@inheritDoc}
      */
     public String execute(TaskList tasks, Ui ui, Storage storage) throws DukeException {
-        // Tasks are displayed as 1-indexed, but they are stored as 0-indexed.
-        int taskIndex = Integer.parseInt(inputStrings[1].trim()) - 1;
-        Task task = tasks.removeTask(taskIndex);
+        try {
+            // Tasks are displayed as 1-indexed, but they are stored as 0-indexed.
+            int taskIndex = Integer.parseInt(inputStrings[1].trim()) - 1;
 
-        return ui.showRemoveTask(task, tasks.size());
+            Task task = tasks.removeTask(taskIndex);
+            return ui.showRemoveTask(task, tasks.size());
+        } catch (NumberFormatException | IndexOutOfBoundsException exception) {
+            throw new InvalidTaskIndexException();
+        }
     }
 
     /**

--- a/src/main/java/commands/MarkCommand.java
+++ b/src/main/java/commands/MarkCommand.java
@@ -4,6 +4,7 @@ import dukeegg.Storage;
 import dukeegg.TaskList;
 import dukeegg.Ui;
 import exceptions.DukeException;
+import exceptions.InvalidTaskIndexException;
 import task.Task;
 
 /**
@@ -35,7 +36,7 @@ public class MarkCommand extends Command {
             task.markTask();
             return ui.showMarkTask(task);
         } catch (NumberFormatException | IndexOutOfBoundsException exception) {
-            throw new DukeException("     ☹ OOPS!!! The index specified is invalid.");
+            throw new InvalidTaskIndexException();
         }
     }
 

--- a/src/main/java/commands/UnmarkCommand.java
+++ b/src/main/java/commands/UnmarkCommand.java
@@ -4,6 +4,7 @@ import dukeegg.Storage;
 import dukeegg.TaskList;
 import dukeegg.Ui;
 import exceptions.DukeException;
+import exceptions.InvalidTaskIndexException;
 import task.Task;
 
 /**
@@ -36,7 +37,7 @@ public class UnmarkCommand extends Command {
 
             return ui.showUnmarkTask(task);
         } catch (NumberFormatException | IndexOutOfBoundsException exception) {
-            throw new DukeException("     ☹ OOPS!!! The index specified is invalid.");
+            throw new InvalidTaskIndexException();
         }
     }
 

--- a/src/main/java/dukeegg/Parser.java
+++ b/src/main/java/dukeegg/Parser.java
@@ -25,7 +25,7 @@ public class Parser {
      * @throws DukeException if an error was thrown during the construction of command.
      */
     public static Command parse(String command) throws DukeException {
-        // Limit of 2 is used to avoid splitting the second argument in fullCommand.
+        // Limit of 2 is used to avoid splitting the second argument.
         String[] inputValues = command.split(" ", 2);
         switch (inputValues[0]) {
         case "bye": {

--- a/src/main/java/dukeegg/Storage.java
+++ b/src/main/java/dukeegg/Storage.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.Scanner;
 
 import exceptions.DukeException;
-import exceptions.InvalidTaskException;
+import exceptions.InvalidTaskDecodedException;
 import task.Deadline;
 import task.Event;
 import task.Task;
@@ -61,14 +61,14 @@ public class Storage {
         switch (taskValues[0]) {
         case "T": {
             if (taskValues.length != 3) {
-                throw new InvalidTaskException(TaskType.T, taskData);
+                throw new InvalidTaskDecodedException(TaskType.T, taskData);
             }
             decodedTask = new Todo(taskValues[2], taskValues[1].equals("1"));
             break;
         }
         case "D": {
             if (taskValues.length != 4) {
-                throw new InvalidTaskException(TaskType.D, taskData);
+                throw new InvalidTaskDecodedException(TaskType.D, taskData);
             }
             decodedTask = new Deadline(taskValues[2], taskValues[1].equals("1"), LocalDateTime.parse(taskValues[3],
                     Task.DATE_TIME_PARSER));
@@ -76,14 +76,14 @@ public class Storage {
         }
         case "E": {
             if (taskValues.length != 4) {
-                throw new InvalidTaskException(TaskType.E, taskData);
+                throw new InvalidTaskDecodedException(TaskType.E, taskData);
             }
             decodedTask = new Event(taskValues[2], taskValues[1].equals("1"), LocalDateTime.parse(taskValues[3],
                     Task.DATE_TIME_PARSER));
             break;
         }
         default:
-            throw new InvalidTaskException(taskData);
+            throw new InvalidTaskDecodedException(taskData);
         }
         return decodedTask;
     }

--- a/src/main/java/exceptions/InvalidTaskDecodedException.java
+++ b/src/main/java/exceptions/InvalidTaskDecodedException.java
@@ -5,7 +5,7 @@ import task.TaskType;
 /**
  * Used when the task data being decoded is invalid.
  */
-public class InvalidTaskException extends DukeException {
+public class InvalidTaskDecodedException extends DukeException {
 
     /**
      * Constructs an exception that indicates that the task data being read from the storage file does not adhere to
@@ -13,7 +13,7 @@ public class InvalidTaskException extends DukeException {
      *
      * @param taskData The specified task data.
      */
-    public InvalidTaskException(String taskData) {
+    public InvalidTaskDecodedException(String taskData) {
         super("😅 OOPS!!! Invalid format for \n" + taskData);
     }
 
@@ -24,7 +24,7 @@ public class InvalidTaskException extends DukeException {
      * @param taskType The specified task type.
      * @param taskData The specified task data.
      */
-    public InvalidTaskException(TaskType taskType, String taskData) {
+    public InvalidTaskDecodedException(TaskType taskType, String taskData) {
         super("😅 OOPS!!! Invalid format for " + taskType.getValue() + "\n" + taskData);
     }
 }

--- a/src/main/java/exceptions/InvalidTaskIndexException.java
+++ b/src/main/java/exceptions/InvalidTaskIndexException.java
@@ -1,0 +1,15 @@
+package exceptions;
+
+import task.TaskType;
+
+/**
+ * Used when the task index being accessed is invalid..
+ */
+public class InvalidTaskIndexException extends DukeException {
+    /**
+     * Constructs an exception that indicates that the task index specified cannot be found.
+     */
+    public InvalidTaskIndexException() {
+        super("☹ OOPS!!! The task at the index specified cannot be found.\n");
+    }
+}


### PR DESCRIPTION
The error message was being defined twice for invalid index access in both `MarkCommand` and `UnmarkCommand`

To address this, I created a new exception class to handle the error message to be generated. I also found out that the `DeleteCommand` was missing the index out of bounds check, so it was also added to the `DeleteCommand`

A new exception class was created to standardise the error message and formatting to minimise the amount of refactoring required when changing the error message content or format.